### PR TITLE
Shopify multicolumn to tabbed section with URL links

### DIFF
--- a/multicolumn-tabs-clean.liquid
+++ b/multicolumn-tabs-clean.liquid
@@ -1,0 +1,749 @@
+{{ 'section-multicolumn.css' | asset_url | stylesheet_tag }}
+{{ 'component-slider.css' | asset_url | stylesheet_tag }}
+
+{%- style -%}
+.section-{{ section.id }}-padding {
+  padding-top: {{ section.settings.padding_top | times: 0.75 | round: 0 }}px;
+  padding-bottom: {{ section.settings.padding_bottom | times: 0.75 | round: 0 }}px;
+}
+strong{
+    font-weight:600;
+  }
+
+@media screen and (min-width: 750px) {
+  .section-{{ section.id }}-padding {
+    padding-top: {{ section.settings.padding_top }}px;
+    padding-bottom: {{ section.settings.padding_bottom }}px;
+  }
+}
+  
+@media screen and (max-width: 749px) {
+  .grid__item {
+    padding-left: 4px;
+    padding-right: 4px;
+  }
+}
+.multicolumn-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: space-between;
+}
+
+.multicolumn-card__image-link {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+  border-radius: 12px;
+  flex-shrink: 0;
+  display: block;
+}
+
+.multicolumn-card__image-link img {
+  border-radius: 12px;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.3s ease;
+}
+
+.multicolumn-card__image {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  top: 0;
+  left: 0;
+  border-radius: 12px;
+}
+
+.zoom-on-hover:hover,
+.zoom-image-link:hover .multicolumn-card__image {
+  transform: scale(1.05);
+  transition: transform 0.3s ease;
+}
+
+.multicolumn-card__info {
+  margin-top: 12px;
+  flex-grow: 0;
+  padding-left: 0;
+}
+
+@media screen and (max-width: 749px) {
+  .multicolumn-card__info {
+    margin-top: 0px;
+    padding-left: 0;
+  }
+}
+
+.media,
+.zoom-image-link {
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.tab-navigation {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 2rem;
+  border-bottom: 1px solid rgba(var(--color-foreground), 0.1);
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tab-button {
+  background: none;
+  border: none;
+  padding: 1rem 2rem;
+  cursor: pointer;
+  font-size: 1.6rem;
+  font-weight: 500;
+  color: rgba(var(--color-foreground), 0.7);
+  text-decoration: none;
+  display: inline-block;
+  position: relative;
+  transition: all 0.3s ease;
+  border-radius: {{ section.settings.tab_border_radius | default: 0 }}px;
+  background-color: {{ section.settings.tab_background_color | default: 'transparent' }};
+  border: {{ section.settings.tab_border_width | default: 0 }}px solid {{ section.settings.tab_border_color | default: 'transparent' }};
+}
+
+.tab-button:hover {
+  color: rgba(var(--color-foreground), 1);
+  background-color: {{ section.settings.tab_hover_background | default: 'rgba(var(--color-foreground), 0.05)' }};
+}
+
+.tab-button.active {
+  color: {{ section.settings.active_tab_text_color | default: 'rgba(var(--color-foreground), 1)' }};
+  background-color: {{ section.settings.active_tab_background | default: 'rgba(var(--color-base-accent-1), 1)' }};
+  border-color: {{ section.settings.active_tab_border_color | default: 'rgba(var(--color-base-accent-1), 1)' }};
+  font-weight: 600;
+}
+
+.tab-button.active::after {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background-color: {{ section.settings.active_tab_underline_color | default: 'rgba(var(--color-base-accent-1), 1)' }};
+}
+
+@media screen and (max-width: 749px) {
+  .tab-navigation {
+    justify-content: flex-start;
+    overflow-x: auto;
+    padding-bottom: 0.5rem;
+    margin-bottom: 1.5rem;
+  }
+  
+  .tab-button {
+    padding: 0.8rem 1.5rem;
+    font-size: 1.4rem;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+}
+
+.tab-content {
+  display: none;
+}
+
+.tab-content.active {
+  display: block;
+}
+
+.tab-content .multicolumn-list {
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+{%- endstyle -%}
+
+{%- liquid
+  assign columns_mobile_int = section.settings.columns_mobile | plus: 0
+  assign show_mobile_slider = false
+  if section.settings.swipe_on_mobile and section.blocks.size > columns_mobile_int
+    assign show_mobile_slider = true
+  endif
+  
+  assign tabs = section.blocks | map: 'settings' | map: 'tab_name' | uniq
+  assign first_tab = tabs.first
+-%}
+
+<div class="multicolumn color-{{ section.settings.color_scheme }} gradient{% unless section.settings.background_style == 'none' and settings.text_boxes_border_thickness > 0 or settings.text_boxes_shadow_opacity > 0 %} background-{{ section.settings.background_style }}{% endunless %}{% if section.settings.title == blank %} no-heading{% endif %}">
+  <div
+    class="page-width section-{{ section.id }}-padding isolate{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}"
+    {% if settings.animations_reveal_on_scroll %}
+      data-cascade
+    {% endif %}
+  >
+    {%- unless section.settings.title == blank -%}
+      <div class="title-wrapper-with-link title-wrapper--self-padded-mobile title-wrapper--no-top-margin">
+        <h1 class="title inline-richtext {{ section.settings.heading_size }}">
+          {{ section.settings.title }}
+        </h1>
+        {%- if section.settings.button_label != blank and show_mobile_slider -%}
+          <a href="{{ section.settings.button_link }}" class="link underlined-link large-up-hide">
+            {{- section.settings.button_label | escape -}}
+          </a>
+        {%- endif -%}
+      </div>
+    {%- endunless -%}
+    
+    <div class="tab-navigation">
+      {%- for tab in tabs -%}
+        {%- if tab != blank -%}
+          {%- assign tab_block = section.blocks | where: 'settings.tab_name', tab | first -%}
+          <a 
+            href="{{ tab_block.settings.tab_url | default: '#' }}"
+            class="tab-button{% if forloop.first %} active{% endif %}"
+            data-tab="{{ tab | handleize }}"
+            onclick="switchTab(event, '{{ tab | handleize }}', '{{ tab_block.settings.tab_url }}')"
+          >
+            {{ tab }}
+          </a>
+        {%- endif -%}
+      {%- endfor -%}
+    </div>
+
+    {%- for tab in tabs -%}
+      {%- if tab != blank -%}
+        <div class="tab-content{% if forloop.first %} active{% endif %}" id="tab-{{ tab | handleize }}">
+          <slider-component class="slider-mobile-gutter">
+            <ul
+              class="multicolumn-list contains-content-container grid grid--{{ section.settings.columns_mobile }}-col-tablet-down grid--{{ section.settings.columns_desktop }}-col-desktop{% if show_mobile_slider %} slider slider--mobile grid--peek{% endif %}"
+              id="Slider-{{ section.id }}-{{ tab | handleize }}"
+              role="list"
+            >
+              {%- liquid
+                assign highest_ratio = 0
+                assign tab_blocks = section.blocks | where: 'settings.tab_name', tab
+                for block in tab_blocks
+                  if block.settings.image.aspect_ratio > highest_ratio
+                    assign highest_ratio = block.settings.image.aspect_ratio
+                  endif
+                endfor
+              -%}
+              {%- for block in tab_blocks -%}
+                {%- assign empty_column = '' -%}
+                {%- if block.settings.image == blank
+                  and block.settings.title == blank
+                  and block.settings.text == blank
+                  and block.settings.link_label == blank
+                -%}
+                  {%- assign empty_column = ' multicolumn-list__item--empty' -%}
+                {%- endif -%}
+
+                <li
+                  id="Slide-{{ section.id }}-{{ forloop.index }}"
+                  class="multicolumn-list__item grid__item{% if section.settings.swipe_on_mobile %} slider__slide{% endif %}{% if section.settings.column_alignment == 'center' %} center{% endif %}{{ empty_column }}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}"
+                  {{ block.shopify_attributes }}
+                  {% if settings.animations_reveal_on_scroll %}
+                    data-cascade
+                    style="--animation-order: {{ forloop.index }};"
+                  {% endif %}
+                >
+                  <div class="multicolumn-card content-container">
+                    {%- if block.settings.image != blank -%}
+                      {% if section.settings.image_ratio == 'adapt' or section.settings.image_ratio == 'circle' %}
+                        {% assign spaced_image = true %}
+                      {% endif %}
+                      <div class="multicolumn-card__image-wrapper multicolumn-card__image-wrapper--{{ section.settings.image_width }}-width{% if section.settings.image_width != 'full' or spaced_image %} multicolumn-card-spacing{% endif %}">
+                        <div
+                          class="media media--transparent media--{{ section.settings.image_ratio }}"
+                          {% if section.settings.image_ratio == 'adapt' %}
+                            style="padding-bottom: {{ 1 | divided_by: highest_ratio | times: 100 }}%;"
+                          {% endif %}
+                        >
+                          {%- liquid
+                            assign number_of_columns = section.settings.columns_desktop
+                            assign number_of_columns_mobile = section.settings.columns_mobile
+                            assign grid_space_desktop = number_of_columns | minus: 1 | times: settings.spacing_grid_horizontal | append: 'px'
+                            assign grid_space_tablet = number_of_columns_mobile | minus: 1 | times: settings.spacing_grid_horizontal | append: 'px'
+                            assign grid_space_mobile = number_of_columns_mobile | minus: 1 | times: settings.spacing_grid_horizontal | divided_by: 2 | append: 'px'
+                            if section.settings.image_width == 'half'
+                              assign image_width = 0.5
+                            elsif section.settings.image_width == 'third'
+                              assign image_width = 0.33
+                            else
+                              assign image_width = 1
+                            endif
+                          -%}
+                          {% capture sizes %}
+                            (min-width: {{ settings.page_width }}px) calc(({{ settings.page_width }}px - {{ grid_space_desktop }}) * {{ image_width }} /  {{ number_of_columns }}),
+                            (min-width: 990px) calc((100vw - {{ grid_space_desktop }}) * {{ image_width }} / {{ number_of_columns }}),
+                            (min-width: 750px) calc((100vw - {{ grid_space_tablet }}) * {{ image_width }} / {{ number_of_columns_mobile }}),
+                            calc((100vw - {{ grid_space_mobile }}) * {{ image_width }} / {{ number_of_columns_mobile }})
+                          {% endcapture %}
+                          
+                       {% if block.settings.link != blank %}
+                        <a href="{{ block.settings.link }}" class="zoom-image-link">
+                       {% endif %}
+                            {{ block.settings.image
+                            | image_url: width: 3200
+                            | image_tag:
+                              widths: '50, 75, 100, 150, 200, 300, 400, 500, 750, 1000, 1250, 1500, 1750, 2000, 2250, 2500, 2750, 3000, 3200',
+                              sizes: sizes,
+                               class: 'multicolumn-card__image zoom-on-hover'
+                            }}
+                      {% if block.settings.link != blank %}
+                            </a>
+                      {% endif %}
+
+                        </div>
+                      </div>
+                    {%- endif -%}
+                    <div class="multicolumn-card__info">
+                      {%- if block.settings.title != blank -%}
+                        <h3 class="inline-richtext">{{ block.settings.title }}</h3>
+                      {%- endif -%}
+                      {%- if block.settings.text != blank -%}
+                        <div class="rte">{{ block.settings.text }}</div>
+                      {%- endif -%}
+                      {%- if block.settings.link_label != blank -%}
+                        <a
+                          class="link animate-arrow"
+                          {% if block.settings.link == blank %}
+                            role="link" aria-disabled="true"
+                          {% else %}
+                            href="{{ block.settings.link }}"
+                          {% endif %}
+                        >
+                          {{- block.settings.link_label | escape -}}
+                          <span class="icon-wrap">&nbsp;{% render 'icon-arrow' %}</span></a
+                        >
+                      {%- endif -%}
+                    </div>
+                  </div>
+                </li>
+              {%- endfor -%}
+            </ul>
+
+            {%- if show_mobile_slider -%}
+              <div class="slider-buttons no-js-hidden medium-hide">
+                <button
+                  type="button"
+                  class="slider-button slider-button--prev"
+                  name="previous"
+                  aria-label="{{ 'general.slider.previous_slide' | t }}"
+                >
+                  {% render 'icon-caret' %}
+                </button>
+                <div class="slider-counter caption">
+                  <span class="slider-counter--current">1</span>
+                  <span aria-hidden="true"> / </span>
+                  <span class="visually-hidden">{{ 'general.slider.of' | t }}</span>
+                  <span class="slider-counter--total">{{ tab_blocks.size }}</span>
+                </div>
+                <button
+                  type="button"
+                  class="slider-button slider-button--next"
+                  name="next"
+                  aria-label="{{ 'general.slider.next_slide' | t }}"
+                >
+                  {% render 'icon-caret' %}
+                </button>
+              </div>
+            {%- endif -%}
+          </slider-component>
+        </div>
+      {%- endif -%}
+    {%- endfor -%}
+    
+    <div class="center{% if show_mobile_slider %} small-hide medium-hide{% endif %}">
+      {%- if section.settings.button_label != blank -%}
+        <a
+          class="button button--primary"
+          {% if section.settings.button_link == blank %}
+            role="link" aria-disabled="true"
+          {% else %}
+            href="{{ section.settings.button_link }}"
+          {% endif %}
+        >
+          {{ section.settings.button_label | escape }}
+        </a>
+      {%- endif -%}
+    </div>
+  </div>
+</div>
+
+<script>
+function switchTab(event, tabId, tabUrl) {
+  if (tabUrl === '#' || tabUrl === '') {
+    event.preventDefault();
+  }
+  
+  const tabButtons = document.querySelectorAll('.tab-button');
+  const tabContents = document.querySelectorAll('.tab-content');
+  
+  tabButtons.forEach(button => button.classList.remove('active'));
+  tabContents.forEach(content => content.classList.remove('active'));
+  
+  event.target.classList.add('active');
+  const targetContent = document.getElementById('tab-' + tabId);
+  if (targetContent) {
+    targetContent.classList.add('active');
+  }
+  
+  if (tabUrl && tabUrl !== '#' && tabUrl !== '') {
+    setTimeout(() => {
+      window.location.href = tabUrl;
+    }, 150);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+  const activeTab = document.querySelector('.tab-button.active');
+  const activeContent = document.querySelector('.tab-content.active');
+  
+  if (!activeTab) {
+    const firstTab = document.querySelector('.tab-button');
+    const firstContent = document.querySelector('.tab-content');
+    
+    if (firstTab) firstTab.classList.add('active');
+    if (firstContent) firstContent.classList.add('active');
+  }
+});
+</script>
+
+{% schema %}
+{
+  "name": "t:sections.multicolumn.name",
+  "class": "section",
+  "tag": "section",
+  "disabled_on": {
+    "groups": ["header", "footer"]
+  },
+  "settings": [
+    {
+      "type": "inline_richtext",
+      "id": "title",
+      "default": "Multicolumn Tabs",
+      "label": "t:sections.multicolumn.settings.title.label"
+    },
+    {
+      "type": "select",
+      "id": "heading_size",
+      "options": [
+        {
+          "value": "h2",
+          "label": "t:sections.all.heading_size.options__1.label"
+        },
+        {
+          "value": "h1",
+          "label": "t:sections.all.heading_size.options__2.label"
+        },
+        {
+          "value": "h0",
+          "label": "t:sections.all.heading_size.options__3.label"
+        }
+      ],
+      "default": "h1",
+      "label": "t:sections.all.heading_size.label"
+    },
+    {
+      "type": "header",
+      "content": "Tab Styling"
+    },
+    {
+      "type": "color",
+      "id": "active_tab_background",
+      "label": "Active Tab Background Color",
+      "default": "#000000"
+    },
+    {
+      "type": "color",
+      "id": "active_tab_text_color",
+      "label": "Active Tab Text Color",
+      "default": "#ffffff"
+    },
+    {
+      "type": "color",
+      "id": "active_tab_border_color",
+      "label": "Active Tab Border Color",
+      "default": "#000000"
+    },
+    {
+      "type": "color",
+      "id": "active_tab_underline_color",
+      "label": "Active Tab Underline Color",
+      "default": "#000000"
+    },
+    {
+      "type": "color",
+      "id": "tab_background_color",
+      "label": "Tab Background Color",
+      "default": "transparent"
+    },
+    {
+      "type": "color",
+      "id": "tab_border_color",
+      "label": "Tab Border Color",
+      "default": "transparent"
+    },
+    {
+      "type": "color",
+      "id": "tab_hover_background",
+      "label": "Tab Hover Background Color",
+      "default": "#f5f5f5"
+    },
+    {
+      "type": "range",
+      "id": "tab_border_radius",
+      "min": 0,
+      "max": 20,
+      "step": 1,
+      "unit": "px",
+      "label": "Tab Border Radius",
+      "default": 0
+    },
+    {
+      "type": "range",
+      "id": "tab_border_width",
+      "min": 0,
+      "max": 5,
+      "step": 1,
+      "unit": "px",
+      "label": "Tab Border Width",
+      "default": 0
+    },
+    {
+      "type": "select",
+      "id": "image_width",
+      "options": [
+        {
+          "value": "third",
+          "label": "t:sections.multicolumn.settings.image_width.options__1.label"
+        },
+        {
+          "value": "half",
+          "label": "t:sections.multicolumn.settings.image_width.options__2.label"
+        },
+        {
+          "value": "full",
+          "label": "t:sections.multicolumn.settings.image_width.options__3.label"
+        }
+      ],
+      "default": "full",
+      "label": "t:sections.multicolumn.settings.image_width.label"
+    },
+    {
+      "type": "select",
+      "id": "image_ratio",
+      "options": [
+        {
+          "value": "adapt",
+          "label": "t:sections.multicolumn.settings.image_ratio.options__1.label"
+        },
+        {
+          "value": "portrait",
+          "label": "t:sections.multicolumn.settings.image_ratio.options__2.label"
+        },
+        {
+          "value": "square",
+          "label": "t:sections.multicolumn.settings.image_ratio.options__3.label"
+        },
+        {
+          "value": "circle",
+          "label": "t:sections.multicolumn.settings.image_ratio.options__4.label"
+        }
+      ],
+      "default": "adapt",
+      "label": "t:sections.multicolumn.settings.image_ratio.label"
+    },
+    {
+      "type": "range",
+      "id": "columns_desktop",
+      "min": 1,
+      "max": 6,
+      "step": 1,
+      "default": 3,
+      "label": "t:sections.multicolumn.settings.columns_desktop.label"
+    },
+    {
+      "type": "select",
+      "id": "column_alignment",
+      "options": [
+        {
+          "value": "left",
+          "label": "t:sections.multicolumn.settings.column_alignment.options__1.label"
+        },
+        {
+          "value": "center",
+          "label": "t:sections.multicolumn.settings.column_alignment.options__2.label"
+        }
+      ],
+      "default": "left",
+      "label": "t:sections.multicolumn.settings.column_alignment.label"
+    },
+    {
+      "type": "select",
+      "id": "background_style",
+      "options": [
+        {
+          "value": "none",
+          "label": "t:sections.multicolumn.settings.background_style.options__1.label"
+        },
+        {
+          "value": "primary",
+          "label": "t:sections.multicolumn.settings.background_style.options__2.label"
+        }
+      ],
+      "default": "primary",
+      "label": "t:sections.multicolumn.settings.background_style.label"
+    },
+    {
+      "type": "text",
+      "id": "button_label",
+      "default": "Button label",
+      "label": "t:sections.multicolumn.settings.button_label.label"
+    },
+    {
+      "type": "url",
+      "id": "button_link",
+      "label": "t:sections.multicolumn.settings.button_link.label"
+    },
+    {
+      "type": "color_scheme",
+      "id": "color_scheme",
+      "label": "t:sections.all.colors.label",
+      "default": "background-1"
+    },
+    {
+      "type": "header",
+      "content": "t:sections.multicolumn.settings.header_mobile.content"
+    },
+    {
+      "type": "select",
+      "id": "columns_mobile",
+      "options": [
+        {
+          "value": "1",
+          "label": "t:sections.multicolumn.settings.columns_mobile.options__1.label"
+        },
+        {
+          "value": "2",
+          "label": "t:sections.multicolumn.settings.columns_mobile.options__2.label"
+        }
+      ],
+      "default": "1",
+      "label": "t:sections.multicolumn.settings.columns_mobile.label"
+    },
+    {
+      "type": "checkbox",
+      "id": "swipe_on_mobile",
+      "default": false,
+      "label": "t:sections.multicolumn.settings.swipe_on_mobile.label"
+    },
+    {
+      "type": "header",
+      "content": "t:sections.all.padding.section_padding_heading"
+    },
+    {
+      "type": "range",
+      "id": "padding_top",
+      "min": 0,
+      "max": 100,
+      "step": 4,
+      "unit": "px",
+      "label": "t:sections.all.padding.padding_top",
+      "default": 36
+    },
+    {
+      "type": "range",
+      "id": "padding_bottom",
+      "min": 0,
+      "max": 100,
+      "step": 4,
+      "unit": "px",
+      "label": "t:sections.all.padding.padding_bottom",
+      "default": 36
+    }
+  ],
+  "blocks": [
+    {
+      "type": "column",
+      "name": "t:sections.multicolumn.blocks.column.name",
+      "settings": [
+        {
+          "type": "text",
+          "id": "tab_name",
+          "label": "Tab Name",
+          "info": "Enter the tab name. Columns with the same tab name will be grouped together."
+        },
+        {
+          "type": "url",
+          "id": "tab_url",
+          "label": "Tab URL",
+          "info": "URL to navigate to when this tab is clicked (optional)"
+        },
+        {
+          "type": "image_picker",
+          "id": "image",
+          "label": "t:sections.multicolumn.blocks.column.settings.image.label"
+        },
+        {
+          "type": "inline_richtext",
+          "id": "title",
+          "default": "Column",
+          "label": "t:sections.multicolumn.blocks.column.settings.title.label"
+        },
+        {
+          "type": "richtext",
+          "id": "text",
+          "default": "<p>Pair text with an image to focus on your chosen product, collection, or blog post. Add details on availability, style, or even provide a review.</p>",
+          "label": "t:sections.multicolumn.blocks.column.settings.text.label"
+        },
+        {
+          "type": "text",
+          "id": "link_label",
+          "label": "t:sections.multicolumn.blocks.column.settings.link_label.label"
+        },
+        {
+          "type": "url",
+          "id": "link",
+          "label": "t:sections.multicolumn.blocks.column.settings.link.label"
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "Multicolumn Tabs",
+      "blocks": [
+        {
+          "type": "column",
+          "settings": {
+            "tab_name": "Tab 1"
+          }
+        },
+        {
+          "type": "column",
+          "settings": {
+            "tab_name": "Tab 1"
+          }
+        },
+        {
+          "type": "column",
+          "settings": {
+            "tab_name": "Tab 2"
+          }
+        },
+        {
+          "type": "column",
+          "settings": {
+            "tab_name": "Tab 2"
+          }
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/multicolumn-tabs-fixed.liquid
+++ b/multicolumn-tabs-fixed.liquid
@@ -1,0 +1,684 @@
+{{ 'section-multicolumn.css' | asset_url | stylesheet_tag }}
+{{ 'component-slider.css' | asset_url | stylesheet_tag }}
+
+{%- style -%}
+.section-{{ section.id }}-padding {
+  padding-top: {{ section.settings.padding_top | times: 0.75 | round: 0 }}px;
+  padding-bottom: {{ section.settings.padding_bottom | times: 0.75 | round: 0 }}px;
+}
+
+strong {
+  font-weight: 600;
+}
+
+@media screen and (min-width: 750px) {
+  .section-{{ section.id }}-padding {
+    padding-top: {{ section.settings.padding_top }}px;
+    padding-bottom: {{ section.settings.padding_bottom }}px;
+  }
+}
+  
+@media screen and (max-width: 749px) {
+  .grid__item {
+    padding-left: 4px;
+    padding-right: 4px;
+  }
+}
+
+.multicolumn-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: space-between;
+}
+
+.multicolumn-card__image-link {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+  border-radius: 12px;
+  flex-shrink: 0;
+  display: block;
+}
+
+.multicolumn-card__image-link img {
+  border-radius: 12px;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.3s ease;
+}
+
+.multicolumn-card__image {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  top: 0;
+  left: 0;
+  border-radius: 12px;
+}
+
+.zoom-on-hover:hover,
+.zoom-image-link:hover .multicolumn-card__image {
+  transform: scale(1.05);
+  transition: transform 0.3s ease;
+}
+
+.multicolumn-card__info {
+  margin-top: 12px;
+  flex-grow: 0;
+  padding-left: 0;
+}
+
+@media screen and (max-width: 749px) {
+  .multicolumn-card__info {
+    margin-top: 0px;
+    padding-left: 0;
+  }
+}
+
+.media,
+.zoom-image-link {
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.tab-navigation {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 2rem;
+  border-bottom: 1px solid rgba(var(--color-foreground), 0.1);
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tab-button {
+  background: none;
+  border: none;
+  padding: 1rem 2rem;
+  cursor: pointer;
+  font-size: 1.6rem;
+  font-weight: 500;
+  color: rgba(var(--color-foreground), 0.7);
+  text-decoration: none;
+  display: inline-block;
+  position: relative;
+  transition: all 0.3s ease;
+  border-radius: {{ section.settings.tab_border_radius | default: 0 }}px;
+  background-color: {{ section.settings.tab_background_color | default: 'transparent' }};
+  border: {{ section.settings.tab_border_width | default: 0 }}px solid {{ section.settings.tab_border_color | default: 'transparent' }};
+}
+
+.tab-button:hover {
+  color: rgba(var(--color-foreground), 1);
+  background-color: {{ section.settings.tab_hover_background | default: 'rgba(var(--color-foreground), 0.05)' }};
+}
+
+.tab-button.active {
+  color: {{ section.settings.active_tab_text_color | default: 'rgba(var(--color-foreground), 1)' }};
+  background-color: {{ section.settings.active_tab_background | default: 'rgba(var(--color-base-accent-1), 1)' }};
+  border-color: {{ section.settings.active_tab_border_color | default: 'rgba(var(--color-base-accent-1), 1)' }};
+  font-weight: 600;
+}
+
+.tab-button.active::after {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background-color: {{ section.settings.active_tab_underline_color | default: 'rgba(var(--color-base-accent-1), 1)' }};
+}
+
+@media screen and (max-width: 749px) {
+  .tab-navigation {
+    justify-content: flex-start;
+    overflow-x: auto;
+    padding-bottom: 0.5rem;
+    margin-bottom: 1.5rem;
+  }
+  
+  .tab-button {
+    padding: 0.8rem 1.5rem;
+    font-size: 1.4rem;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+}
+
+.tab-content {
+  display: none;
+}
+
+.tab-content.active {
+  display: block;
+}
+
+.tab-content .multicolumn-list {
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+{%- endstyle -%}
+
+{%- liquid
+  assign columns_mobile_int = section.settings.columns_mobile | plus: 0
+  assign show_mobile_slider = false
+  if section.settings.swipe_on_mobile and section.blocks.size > columns_mobile_int
+    assign show_mobile_slider = true
+  endif
+  
+  assign tabs = section.blocks | map: 'settings' | map: 'tab_name' | uniq
+  assign first_tab = tabs.first
+-%}
+
+<div class="multicolumn color-{{ section.settings.color_scheme }} gradient{% unless section.settings.background_style == 'none' and settings.text_boxes_border_thickness > 0 or settings.text_boxes_shadow_opacity > 0 %} background-{{ section.settings.background_style }}{% endunless %}{% if section.settings.title == blank %} no-heading{% endif %}">
+  <div class="page-width section-{{ section.id }}-padding isolate{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}"{% if settings.animations_reveal_on_scroll %} data-cascade{% endif %}>
+    {%- unless section.settings.title == blank -%}
+      <div class="title-wrapper-with-link title-wrapper--self-padded-mobile title-wrapper--no-top-margin">
+        <h1 class="title inline-richtext {{ section.settings.heading_size }}">
+          {{ section.settings.title }}
+        </h1>
+        {%- if section.settings.button_label != blank and show_mobile_slider -%}
+          <a href="{{ section.settings.button_link }}" class="link underlined-link large-up-hide">
+            {{- section.settings.button_label | escape -}}
+          </a>
+        {%- endif -%}
+      </div>
+    {%- endunless -%}
+    
+    <div class="tab-navigation">
+      {%- for tab in tabs -%}
+        {%- if tab != blank -%}
+          {%- assign tab_block = section.blocks | where: 'settings.tab_name', tab | first -%}
+          <a href="{{ tab_block.settings.tab_url | default: '#' }}" class="tab-button{% if forloop.first %} active{% endif %}" data-tab="{{ tab | handleize }}" onclick="switchTab(event, '{{ tab | handleize }}', '{{ tab_block.settings.tab_url }}')">
+            {{ tab }}
+          </a>
+        {%- endif -%}
+      {%- endfor -%}
+    </div>
+
+    {%- for tab in tabs -%}
+      {%- if tab != blank -%}
+        <div class="tab-content{% if forloop.first %} active{% endif %}" id="tab-{{ tab | handleize }}">
+          <slider-component class="slider-mobile-gutter">
+            <ul class="multicolumn-list contains-content-container grid grid--{{ section.settings.columns_mobile }}-col-tablet-down grid--{{ section.settings.columns_desktop }}-col-desktop{% if show_mobile_slider %} slider slider--mobile grid--peek{% endif %}" id="Slider-{{ section.id }}-{{ tab | handleize }}" role="list">
+              {%- liquid
+                assign highest_ratio = 0
+                assign tab_blocks = section.blocks | where: 'settings.tab_name', tab
+                for block in tab_blocks
+                  if block.settings.image.aspect_ratio > highest_ratio
+                    assign highest_ratio = block.settings.image.aspect_ratio
+                  endif
+                endfor
+              -%}
+              {%- for block in tab_blocks -%}
+                {%- assign empty_column = '' -%}
+                {%- if block.settings.image == blank and block.settings.title == blank and block.settings.text == blank and block.settings.link_label == blank -%}
+                  {%- assign empty_column = ' multicolumn-list__item--empty' -%}
+                {%- endif -%}
+
+                <li id="Slide-{{ section.id }}-{{ forloop.index }}" class="multicolumn-list__item grid__item{% if section.settings.swipe_on_mobile %} slider__slide{% endif %}{% if section.settings.column_alignment == 'center' %} center{% endif %}{{ empty_column }}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}" {{ block.shopify_attributes }}{% if settings.animations_reveal_on_scroll %} data-cascade style="--animation-order: {{ forloop.index }};"{% endif %}>
+                  <div class="multicolumn-card content-container">
+                    {%- if block.settings.image != blank -%}
+                      {% if section.settings.image_ratio == 'adapt' or section.settings.image_ratio == 'circle' %}
+                        {% assign spaced_image = true %}
+                      {% endif %}
+                      <div class="multicolumn-card__image-wrapper multicolumn-card__image-wrapper--{{ section.settings.image_width }}-width{% if section.settings.image_width != 'full' or spaced_image %} multicolumn-card-spacing{% endif %}">
+                        <div class="media media--transparent media--{{ section.settings.image_ratio }}"{% if section.settings.image_ratio == 'adapt' %} style="padding-bottom: {{ 1 | divided_by: highest_ratio | times: 100 }}%;"{% endif %}>
+                          {%- liquid
+                            assign number_of_columns = section.settings.columns_desktop
+                            assign number_of_columns_mobile = section.settings.columns_mobile
+                            assign grid_space_desktop = number_of_columns | minus: 1 | times: settings.spacing_grid_horizontal | plus: 100 | append: 'px'
+                            assign grid_space_tablet = number_of_columns_mobile | minus: 1 | times: settings.spacing_grid_horizontal | plus: 100 | append: 'px'
+                            assign grid_space_mobile = number_of_columns_mobile | minus: 1 | times: settings.spacing_grid_horizontal | divided_by: 2 | plus: 30 | append: 'px'
+                            if section.settings.image_width == 'half'
+                              assign image_width = 0.5
+                            elsif section.settings.image_width == 'third'
+                              assign image_width = 0.33
+                            else
+                              assign image_width = 1
+                            endif
+                          -%}
+                          {% capture sizes %}(min-width: {{ settings.page_width }}px) calc(({{ settings.page_width }}px - {{ grid_space_desktop }}) * {{ image_width }} /  {{ number_of_columns }}), (min-width: 990px) calc((100vw - {{ grid_space_desktop }}) * {{ image_width }} / {{ number_of_columns }}), (min-width: 750px) calc((100vw - {{ grid_space_tablet }}) * {{ image_width }} / {{ number_of_columns_mobile }}), calc((100vw - {{ grid_space_mobile }}) * {{ image_width }} / {{ number_of_columns_mobile }}){% endcapture %}
+                          
+                          {% if block.settings.link != blank %}
+                            <a href="{{ block.settings.link }}" class="zoom-image-link">
+                          {% endif %}
+                          {{ block.settings.image | image_url: width: 3200 | image_tag: widths: '50, 75, 100, 150, 200, 300, 400, 500, 750, 1000, 1250, 1500, 1750, 2000, 2250, 2500, 2750, 3000, 3200', sizes: sizes, class: 'multicolumn-card__image zoom-on-hover' }}
+                          {% if block.settings.link != blank %}
+                            </a>
+                          {% endif %}
+                        </div>
+                      </div>
+                    {%- endif -%}
+                    <div class="multicolumn-card__info">
+                      {%- if block.settings.title != blank -%}
+                        <h3 class="inline-richtext">{{ block.settings.title }}</h3>
+                      {%- endif -%}
+                      {%- if block.settings.text != blank -%}
+                        <div class="rte">{{ block.settings.text }}</div>
+                      {%- endif -%}
+                      {%- if block.settings.link_label != blank -%}
+                        <a class="link animate-arrow"{% if block.settings.link == blank %} role="link" aria-disabled="true"{% else %} href="{{ block.settings.link }}"{% endif %}>
+                          {{- block.settings.link_label | escape -}}
+                          <span class="icon-wrap">&nbsp;{% render 'icon-arrow' %}</span>
+                        </a>
+                      {%- endif -%}
+                    </div>
+                  </div>
+                </li>
+              {%- endfor -%}
+            </ul>
+
+            {%- if show_mobile_slider -%}
+              <div class="slider-buttons no-js-hidden medium-hide">
+                <button type="button" class="slider-button slider-button--prev" name="previous" aria-label="{{ 'general.slider.previous_slide' | t }}">
+                  {% render 'icon-caret' %}
+                </button>
+                <div class="slider-counter caption">
+                  <span class="slider-counter--current">1</span>
+                  <span aria-hidden="true"> / </span>
+                  <span class="visually-hidden">{{ 'general.slider.of' | t }}</span>
+                  <span class="slider-counter--total">{{ tab_blocks.size }}</span>
+                </div>
+                <button type="button" class="slider-button slider-button--next" name="next" aria-label="{{ 'general.slider.next_slide' | t }}">
+                  {% render 'icon-caret' %}
+                </button>
+              </div>
+            {%- endif -%}
+          </slider-component>
+        </div>
+      {%- endif -%}
+    {%- endfor -%}
+    
+    <div class="center{% if show_mobile_slider %} small-hide medium-hide{% endif %}">
+      {%- if section.settings.button_label != blank -%}
+        <a class="button button--primary"{% if section.settings.button_link == blank %} role="link" aria-disabled="true"{% else %} href="{{ section.settings.button_link }}"{% endif %}>
+          {{ section.settings.button_label | escape }}
+        </a>
+      {%- endif -%}
+    </div>
+  </div>
+</div>
+
+<script>
+function switchTab(event, tabId, tabUrl) {
+  if (tabUrl === '#' || tabUrl === '') {
+    event.preventDefault();
+  }
+  
+  const tabButtons = document.querySelectorAll('.tab-button');
+  const tabContents = document.querySelectorAll('.tab-content');
+  
+  tabButtons.forEach(button => button.classList.remove('active'));
+  tabContents.forEach(content => content.classList.remove('active'));
+  
+  event.target.classList.add('active');
+  const targetContent = document.getElementById('tab-' + tabId);
+  if (targetContent) {
+    targetContent.classList.add('active');
+  }
+  
+  if (tabUrl && tabUrl !== '#' && tabUrl !== '') {
+    setTimeout(() => {
+      window.location.href = tabUrl;
+    }, 150);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+  const activeTab = document.querySelector('.tab-button.active');
+  const activeContent = document.querySelector('.tab-content.active');
+  
+  if (!activeTab) {
+    const firstTab = document.querySelector('.tab-button');
+    const firstContent = document.querySelector('.tab-content');
+    
+    if (firstTab) firstTab.classList.add('active');
+    if (firstContent) firstContent.classList.add('active');
+  }
+});
+</script>
+
+{% schema %}
+{
+  "name": "t:sections.multicolumn.name",
+  "class": "section",
+  "tag": "section",
+  "disabled_on": {
+    "groups": ["header", "footer"]
+  },
+  "settings": [
+    {
+      "type": "inline_richtext",
+      "id": "title",
+      "default": "Multicolumn Tabs",
+      "label": "t:sections.multicolumn.settings.title.label"
+    },
+    {
+      "type": "select",
+      "id": "heading_size",
+      "options": [
+        {
+          "value": "h2",
+          "label": "t:sections.all.heading_size.options__1.label"
+        },
+        {
+          "value": "h1",
+          "label": "t:sections.all.heading_size.options__2.label"
+        },
+        {
+          "value": "h0",
+          "label": "t:sections.all.heading_size.options__3.label"
+        }
+      ],
+      "default": "h1",
+      "label": "t:sections.all.heading_size.label"
+    },
+    {
+      "type": "header",
+      "content": "Tab Styling"
+    },
+    {
+      "type": "color",
+      "id": "active_tab_background",
+      "label": "Active Tab Background Color",
+      "default": "#000000"
+    },
+    {
+      "type": "color",
+      "id": "active_tab_text_color",
+      "label": "Active Tab Text Color",
+      "default": "#ffffff"
+    },
+    {
+      "type": "color",
+      "id": "active_tab_border_color",
+      "label": "Active Tab Border Color",
+      "default": "#000000"
+    },
+    {
+      "type": "color",
+      "id": "active_tab_underline_color",
+      "label": "Active Tab Underline Color",
+      "default": "#000000"
+    },
+    {
+      "type": "color",
+      "id": "tab_background_color",
+      "label": "Tab Background Color",
+      "default": "transparent"
+    },
+    {
+      "type": "color",
+      "id": "tab_border_color",
+      "label": "Tab Border Color",
+      "default": "transparent"
+    },
+    {
+      "type": "color",
+      "id": "tab_hover_background",
+      "label": "Tab Hover Background Color",
+      "default": "#f5f5f5"
+    },
+    {
+      "type": "range",
+      "id": "tab_border_radius",
+      "min": 0,
+      "max": 20,
+      "step": 1,
+      "unit": "px",
+      "label": "Tab Border Radius",
+      "default": 0
+    },
+    {
+      "type": "range",
+      "id": "tab_border_width",
+      "min": 0,
+      "max": 5,
+      "step": 1,
+      "unit": "px",
+      "label": "Tab Border Width",
+      "default": 0
+    },
+    {
+      "type": "select",
+      "id": "image_width",
+      "options": [
+        {
+          "value": "third",
+          "label": "t:sections.multicolumn.settings.image_width.options__1.label"
+        },
+        {
+          "value": "half",
+          "label": "t:sections.multicolumn.settings.image_width.options__2.label"
+        },
+        {
+          "value": "full",
+          "label": "t:sections.multicolumn.settings.image_width.options__3.label"
+        }
+      ],
+      "default": "full",
+      "label": "t:sections.multicolumn.settings.image_width.label"
+    },
+    {
+      "type": "select",
+      "id": "image_ratio",
+      "options": [
+        {
+          "value": "adapt",
+          "label": "t:sections.multicolumn.settings.image_ratio.options__1.label"
+        },
+        {
+          "value": "portrait",
+          "label": "t:sections.multicolumn.settings.image_ratio.options__2.label"
+        },
+        {
+          "value": "square",
+          "label": "t:sections.multicolumn.settings.image_ratio.options__3.label"
+        },
+        {
+          "value": "circle",
+          "label": "t:sections.multicolumn.settings.image_ratio.options__4.label"
+        }
+      ],
+      "default": "adapt",
+      "label": "t:sections.multicolumn.settings.image_ratio.label"
+    },
+    {
+      "type": "range",
+      "id": "columns_desktop",
+      "min": 1,
+      "max": 6,
+      "step": 1,
+      "default": 3,
+      "label": "t:sections.multicolumn.settings.columns_desktop.label"
+    },
+    {
+      "type": "select",
+      "id": "column_alignment",
+      "options": [
+        {
+          "value": "left",
+          "label": "t:sections.multicolumn.settings.column_alignment.options__1.label"
+        },
+        {
+          "value": "center",
+          "label": "t:sections.multicolumn.settings.column_alignment.options__2.label"
+        }
+      ],
+      "default": "left",
+      "label": "t:sections.multicolumn.settings.column_alignment.label"
+    },
+    {
+      "type": "select",
+      "id": "background_style",
+      "options": [
+        {
+          "value": "none",
+          "label": "t:sections.multicolumn.settings.background_style.options__1.label"
+        },
+        {
+          "value": "primary",
+          "label": "t:sections.multicolumn.settings.background_style.options__2.label"
+        }
+      ],
+      "default": "primary",
+      "label": "t:sections.multicolumn.settings.background_style.label"
+    },
+    {
+      "type": "text",
+      "id": "button_label",
+      "default": "Button label",
+      "label": "t:sections.multicolumn.settings.button_label.label"
+    },
+    {
+      "type": "url",
+      "id": "button_link",
+      "label": "t:sections.multicolumn.settings.button_link.label"
+    },
+    {
+      "type": "color_scheme",
+      "id": "color_scheme",
+      "label": "t:sections.all.colors.label",
+      "default": "background-1"
+    },
+    {
+      "type": "header",
+      "content": "t:sections.multicolumn.settings.header_mobile.content"
+    },
+    {
+      "type": "select",
+      "id": "columns_mobile",
+      "options": [
+        {
+          "value": "1",
+          "label": "t:sections.multicolumn.settings.columns_mobile.options__1.label"
+        },
+        {
+          "value": "2",
+          "label": "t:sections.multicolumn.settings.columns_mobile.options__2.label"
+        }
+      ],
+      "default": "1",
+      "label": "t:sections.multicolumn.settings.columns_mobile.label"
+    },
+    {
+      "type": "checkbox",
+      "id": "swipe_on_mobile",
+      "default": false,
+      "label": "t:sections.multicolumn.settings.swipe_on_mobile.label"
+    },
+    {
+      "type": "header",
+      "content": "t:sections.all.padding.section_padding_heading"
+    },
+    {
+      "type": "range",
+      "id": "padding_top",
+      "min": 0,
+      "max": 100,
+      "step": 4,
+      "unit": "px",
+      "label": "t:sections.all.padding.padding_top",
+      "default": 36
+    },
+    {
+      "type": "range",
+      "id": "padding_bottom",
+      "min": 0,
+      "max": 100,
+      "step": 4,
+      "unit": "px",
+      "label": "t:sections.all.padding.padding_bottom",
+      "default": 36
+    }
+  ],
+  "blocks": [
+    {
+      "type": "column",
+      "name": "t:sections.multicolumn.blocks.column.name",
+      "settings": [
+        {
+          "type": "text",
+          "id": "tab_name",
+          "label": "Tab Name",
+          "info": "Enter the tab name. Columns with the same tab name will be grouped together."
+        },
+        {
+          "type": "url",
+          "id": "tab_url",
+          "label": "Tab URL",
+          "info": "URL to navigate to when this tab is clicked (optional)"
+        },
+        {
+          "type": "image_picker",
+          "id": "image",
+          "label": "t:sections.multicolumn.blocks.column.settings.image.label"
+        },
+        {
+          "type": "inline_richtext",
+          "id": "title",
+          "default": "Column",
+          "label": "t:sections.multicolumn.blocks.column.settings.title.label"
+        },
+        {
+          "type": "richtext",
+          "id": "text",
+          "default": "<p>Pair text with an image to focus on your chosen product, collection, or blog post. Add details on availability, style, or even provide a review.</p>",
+          "label": "t:sections.multicolumn.blocks.column.settings.text.label"
+        },
+        {
+          "type": "text",
+          "id": "link_label",
+          "label": "t:sections.multicolumn.blocks.column.settings.link_label.label"
+        },
+        {
+          "type": "url",
+          "id": "link",
+          "label": "t:sections.multicolumn.blocks.column.settings.link.label"
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "Multicolumn Tabs",
+      "blocks": [
+        {
+          "type": "column",
+          "settings": {
+            "tab_name": "Tab 1"
+          }
+        },
+        {
+          "type": "column",
+          "settings": {
+            "tab_name": "Tab 1"
+          }
+        },
+        {
+          "type": "column",
+          "settings": {
+            "tab_name": "Tab 2"
+          }
+        },
+        {
+          "type": "column",
+          "settings": {
+            "tab_name": "Tab 2"
+          }
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}

--- a/multicolumn-tabs.liquid
+++ b/multicolumn-tabs.liquid
@@ -1,0 +1,765 @@
+{{ 'section-multicolumn.css' | asset_url | stylesheet_tag }}
+{{ 'component-slider.css' | asset_url | stylesheet_tag }}
+
+{%- style -%}
+.section-{{ section.id }}-padding {
+  padding-top: {{ section.settings.padding_top | times: 0.75 | round: 0 }}px;
+  padding-bottom: {{ section.settings.padding_bottom | times: 0.75 | round: 0 }}px;
+}
+strong{
+    font-weight:600;
+  }
+
+@media screen and (min-width: 750px) {
+  .section-{{ section.id }}-padding {
+    padding-top: {{ section.settings.padding_top }}px;
+    padding-bottom: {{ section.settings.padding_bottom }}px;
+  }
+}
+  
+@media screen and (max-width: 749px) {
+  .grid__item {
+    padding-left: 4px;
+    padding-right: 4px;
+  }
+}
+.multicolumn-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: space-between;
+}
+
+.multicolumn-card__image-link {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3; /* or 1 / 1 for square images */
+  overflow: hidden;
+  border-radius: 12px;
+  flex-shrink: 0;
+  display: block;
+}
+
+.multicolumn-card__image-link img {
+  border-radius: 12px;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.3s ease;
+}
+
+.multicolumn-card__image {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  top: 0;
+  left: 0;
+  border-radius: 12px;
+}
+
+.zoom-on-hover:hover,
+.zoom-image-link:hover .multicolumn-card__image {
+  transform: scale(1.05);
+  transition: transform 0.3s ease;
+}
+
+.multicolumn-card__info {
+  margin-top: 12px;
+  flex-grow: 0;
+  padding-left: 0;
+}
+
+@media screen and (max-width: 749px) {
+  .multicolumn-card__info {
+    margin-top: 0px; /* reduce the space between image and link */
+    padding-left: 0;
+  }
+}
+
+/* Optional wrapper for hover zoom to respect border-radius */
+.media,
+.zoom-image-link {
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+/* Tab Navigation Styles */
+.tab-navigation {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 2rem;
+  border-bottom: 1px solid rgba(var(--color-foreground), 0.1);
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tab-button {
+  background: none;
+  border: none;
+  padding: 1rem 2rem;
+  cursor: pointer;
+  font-size: 1.6rem;
+  font-weight: 500;
+  color: rgba(var(--color-foreground), 0.7);
+  text-decoration: none;
+  display: inline-block;
+  position: relative;
+  transition: all 0.3s ease;
+  border-radius: {{ section.settings.tab_border_radius | default: 0 }}px;
+  background-color: {{ section.settings.tab_background_color | default: 'transparent' }};
+  border: {{ section.settings.tab_border_width | default: 0 }}px solid {{ section.settings.tab_border_color | default: 'transparent' }};
+}
+
+.tab-button:hover {
+  color: rgba(var(--color-foreground), 1);
+  background-color: {{ section.settings.tab_hover_background | default: 'rgba(var(--color-foreground), 0.05)' }};
+}
+
+.tab-button.active {
+  color: {{ section.settings.active_tab_text_color | default: 'rgba(var(--color-foreground), 1)' }};
+  background-color: {{ section.settings.active_tab_background | default: 'rgba(var(--color-base-accent-1), 1)' }};
+  border-color: {{ section.settings.active_tab_border_color | default: 'rgba(var(--color-base-accent-1), 1)' }};
+  font-weight: 600;
+}
+
+.tab-button.active::after {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background-color: {{ section.settings.active_tab_underline_color | default: 'rgba(var(--color-base-accent-1), 1)' }};
+}
+
+@media screen and (max-width: 749px) {
+  .tab-navigation {
+    justify-content: flex-start;
+    overflow-x: auto;
+    padding-bottom: 0.5rem;
+    margin-bottom: 1.5rem;
+  }
+  
+  .tab-button {
+    padding: 0.8rem 1.5rem;
+    font-size: 1.4rem;
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+}
+
+/* Tab Content Styles */
+.tab-content {
+  display: none;
+}
+
+.tab-content.active {
+  display: block;
+}
+
+.tab-content .multicolumn-list {
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+{%- endstyle -%}
+
+{%- liquid
+  assign columns_mobile_int = section.settings.columns_mobile | plus: 0
+  assign show_mobile_slider = false
+  if section.settings.swipe_on_mobile and section.blocks.size > columns_mobile_int
+    assign show_mobile_slider = true
+  endif
+  
+  # Group blocks by tab (first block of each group becomes the tab)
+  assign tabs = section.blocks | map: 'settings' | map: 'tab_name' | uniq
+  assign first_tab = tabs.first
+-%}
+
+<div class="multicolumn color-{{ section.settings.color_scheme }} gradient{% unless section.settings.background_style == 'none' and settings.text_boxes_border_thickness > 0 or settings.text_boxes_shadow_opacity > 0 %} background-{{ section.settings.background_style }}{% endunless %}{% if section.settings.title == blank %} no-heading{% endif %}">
+  <div
+    class="page-width section-{{ section.id }}-padding isolate{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}"
+    {% if settings.animations_reveal_on_scroll %}
+      data-cascade
+    {% endif %}
+  >
+    {%- unless section.settings.title == blank -%}
+      <div class="title-wrapper-with-link title-wrapper--self-padded-mobile title-wrapper--no-top-margin">
+        <h1 class="title inline-richtext {{ section.settings.heading_size }}">
+          {{ section.settings.title }}
+        </h1>
+        {%- if section.settings.button_label != blank and show_mobile_slider -%}
+          <a href="{{ section.settings.button_link }}" class="link underlined-link large-up-hide">
+            {{- section.settings.button_label | escape -}}
+          </a>
+        {%- endif -%}
+      </div>
+    {%- endunless -%}
+    
+    <!-- Tab Navigation -->
+    <div class="tab-navigation">
+      {%- for tab in tabs -%}
+        {%- if tab != blank -%}
+          {%- assign tab_block = section.blocks | where: 'settings.tab_name', tab | first -%}
+          <a 
+            href="{{ tab_block.settings.tab_url | default: '#' }}"
+            class="tab-button{% if forloop.first %} active{% endif %}"
+            data-tab="{{ tab | handleize }}"
+            onclick="switchTab(event, '{{ tab | handleize }}', '{{ tab_block.settings.tab_url }}')"
+          >
+            {{ tab }}
+          </a>
+        {%- endif -%}
+      {%- endfor -%}
+    </div>
+
+    <!-- Tab Contents -->
+    {%- for tab in tabs -%}
+      {%- if tab != blank -%}
+        <div class="tab-content{% if forloop.first %} active{% endif %}" id="tab-{{ tab | handleize }}">
+          <slider-component class="slider-mobile-gutter">
+            <ul
+              class="multicolumn-list contains-content-container grid grid--{{ section.settings.columns_mobile }}-col-tablet-down grid--{{ section.settings.columns_desktop }}-col-desktop{% if show_mobile_slider %} slider slider--mobile grid--peek{% endif %}"
+              id="Slider-{{ section.id }}-{{ tab | handleize }}"
+              role="list"
+            >
+              {%- liquid
+                assign highest_ratio = 0
+                assign tab_blocks = section.blocks | where: 'settings.tab_name', tab
+                for block in tab_blocks
+                  if block.settings.image.aspect_ratio > highest_ratio
+                    assign highest_ratio = block.settings.image.aspect_ratio
+                  endif
+                endfor
+              -%}
+              {%- for block in tab_blocks -%}
+                {%- assign empty_column = '' -%}
+                {%- if block.settings.image == blank
+                  and block.settings.title == blank
+                  and block.settings.text == blank
+                  and block.settings.link_label == blank
+                -%}
+                  {%- assign empty_column = ' multicolumn-list__item--empty' -%}
+                {%- endif -%}
+
+                <li
+                  id="Slide-{{ section.id }}-{{ forloop.index }}"
+                  class="multicolumn-list__item grid__item{% if section.settings.swipe_on_mobile %} slider__slide{% endif %}{% if section.settings.column_alignment == 'center' %} center{% endif %}{{ empty_column }}{% if settings.animations_reveal_on_scroll %} scroll-trigger animate--slide-in{% endif %}"
+                  {{ block.shopify_attributes }}
+                  {% if settings.animations_reveal_on_scroll %}
+                    data-cascade
+                    style="--animation-order: {{ forloop.index }};"
+                  {% endif %}
+                >
+                  <div class="multicolumn-card content-container">
+                    {%- if block.settings.image != blank -%}
+                      {% if section.settings.image_ratio == 'adapt' or section.settings.image_ratio == 'circle' %}
+                        {% assign spaced_image = true %}
+                      {% endif %}
+                      <div class="multicolumn-card__image-wrapper multicolumn-card__image-wrapper--{{ section.settings.image_width }}-width{% if section.settings.image_width != 'full' or spaced_image %} multicolumn-card-spacing{% endif %}">
+                        <div
+                          class="media media--transparent media--{{ section.settings.image_ratio }}"
+                          {% if section.settings.image_ratio == 'adapt' %}
+                            style="padding-bottom: {{ 1 | divided_by: highest_ratio | times: 100 }}%;"
+                          {% endif %}
+                        >
+                          {%- liquid
+                            assign number_of_columns = section.settings.columns_desktop
+                            assign number_of_columns_mobile = section.settings.columns_mobile
+                            assign grid_space_desktop = number_of_columns | minus: 1 | times: settings.spacing_grid_horizontal | plus: 100 | append: 'px'
+                            assign grid_space_tablet = number_of_columns_mobile | minus: 1 | times: settings.spacing_grid_horizontal | plus: 100 | append: 'px'
+                            assign grid_space_mobile = number_of_columns_mobile | minus: 1 | times: settings.spacing_grid_horizontal | divided_by: 2 | plus: 30 | append: 'px'
+                            if section.settings.image_width == 'half'
+                              assign image_width = 0.5
+                            elsif section.settings.image_width == 'third'
+                              assign image_width = 0.33
+                            else
+                              assign image_width = 1
+                            endif
+                          -%}
+                          {% capture sizes %}
+                            (min-width: {{ settings.page_width }}px) calc(({{ settings.page_width }}px - {{ grid_space_desktop }}) * {{ image_width }} /  {{ number_of_columns }}),
+                            (min-width: 990px) calc((100vw - {{ grid_space_desktop }}) * {{ image_width }} / {{ number_of_columns }}),
+                            (min-width: 750px) calc((100vw - {{ grid_space_tablet }}) * {{ image_width }} / {{ number_of_columns_mobile }}),
+                            calc((100vw - {{ grid_space_mobile }}) * {{ image_width }} / {{ number_of_columns_mobile }})
+                          {% endcapture %}
+                          
+                        {% comment %}
+                          Adding link to image in the secion below.
+                        {% endcomment %}
+                       {% if block.settings.link != blank %}
+                        <a href="{{ block.settings.link }}" class="zoom-image-link">
+                       {% endif %}
+                            {{ block.settings.image
+                            | image_url: width: 3200
+                            | image_tag:
+                              widths: '50, 75, 100, 150, 200, 300, 400, 500, 750, 1000, 1250, 1500, 1750, 2000, 2250, 2500, 2750, 3000, 3200',
+                              sizes: sizes,
+                               class: 'multicolumn-card__image zoom-on-hover'
+                            }}
+                      {% if block.settings.link != blank %}
+                            </a>
+                      {% endif %}
+
+                        </div>
+                      </div>
+                    {%- endif -%}
+                    <div class="multicolumn-card__info">
+                      {%- if block.settings.title != blank -%}
+                        <h3 class="inline-richtext">{{ block.settings.title }}</h3>
+                      {%- endif -%}
+                      {%- if block.settings.text != blank -%}
+                        <div class="rte">{{ block.settings.text }}</div>
+                      {%- endif -%}
+                      {%- if block.settings.link_label != blank -%}
+                        <a
+                          class="link animate-arrow"
+                          {% if block.settings.link == blank %}
+                            role="link" aria-disabled="true"
+                          {% else %}
+                            href="{{ block.settings.link }}"
+                          {% endif %}
+                        >
+                          {{- block.settings.link_label | escape -}}
+                          <span class="icon-wrap">&nbsp;{% render 'icon-arrow' %}</span></a
+                        >
+                      {%- endif -%}
+                    </div>
+                  </div>
+                </li>
+              {%- endfor -%}
+            </ul>
+
+            {%- if show_mobile_slider -%}
+              <div class="slider-buttons no-js-hidden medium-hide">
+                <button
+                  type="button"
+                  class="slider-button slider-button--prev"
+                  name="previous"
+                  aria-label="{{ 'general.slider.previous_slide' | t }}"
+                >
+                  {% render 'icon-caret' %}
+                </button>
+                <div class="slider-counter caption">
+                  <span class="slider-counter--current">1</span>
+                  <span aria-hidden="true"> / </span>
+                  <span class="visually-hidden">{{ 'general.slider.of' | t }}</span>
+                  <span class="slider-counter--total">{{ tab_blocks.size }}</span>
+                </div>
+                <button
+                  type="button"
+                  class="slider-button slider-button--next"
+                  name="next"
+                  aria-label="{{ 'general.slider.next_slide' | t }}"
+                >
+                  {% render 'icon-caret' %}
+                </button>
+              </div>
+            {%- endif -%}
+          </slider-component>
+        </div>
+      {%- endif -%}
+    {%- endfor -%}
+    
+    <div class="center{% if show_mobile_slider %} small-hide medium-hide{% endif %}">
+      {%- if section.settings.button_label != blank -%}
+        <a
+          class="button button--primary"
+          {% if section.settings.button_link == blank %}
+            role="link" aria-disabled="true"
+          {% else %}
+            href="{{ section.settings.button_link }}"
+          {% endif %}
+        >
+          {{ section.settings.button_label | escape }}
+        </a>
+      {%- endif -%}
+    </div>
+  </div>
+</div>
+
+<script>
+function switchTab(event, tabId, tabUrl) {
+  // Prevent default link behavior if we're staying on the same page
+  if (tabUrl === '#' || tabUrl === '') {
+    event.preventDefault();
+  }
+  
+  // Remove active class from all tabs and content
+  const tabButtons = document.querySelectorAll('.tab-button');
+  const tabContents = document.querySelectorAll('.tab-content');
+  
+  tabButtons.forEach(button => button.classList.remove('active'));
+  tabContents.forEach(content => content.classList.remove('active'));
+  
+  // Add active class to clicked tab and corresponding content
+  event.target.classList.add('active');
+  const targetContent = document.getElementById('tab-' + tabId);
+  if (targetContent) {
+    targetContent.classList.add('active');
+  }
+  
+  // If there's a URL and it's not just a hash, navigate to it
+  if (tabUrl && tabUrl !== '#' && tabUrl !== '') {
+    // Small delay to show the active state before navigation
+    setTimeout(() => {
+      window.location.href = tabUrl;
+    }, 150);
+  }
+}
+
+// Initialize tabs on page load
+document.addEventListener('DOMContentLoaded', function() {
+  // Set first tab as active if none are active
+  const activeTab = document.querySelector('.tab-button.active');
+  const activeContent = document.querySelector('.tab-content.active');
+  
+  if (!activeTab) {
+    const firstTab = document.querySelector('.tab-button');
+    const firstContent = document.querySelector('.tab-content');
+    
+    if (firstTab) firstTab.classList.add('active');
+    if (firstContent) firstContent.classList.add('active');
+  }
+});
+</script>
+
+{% schema %}
+{
+  "name": "t:sections.multicolumn.name",
+  "class": "section",
+  "tag": "section",
+  "disabled_on": {
+    "groups": ["header", "footer"]
+  },
+  "settings": [
+    {
+      "type": "inline_richtext",
+      "id": "title",
+      "default": "Multicolumn Tabs",
+      "label": "t:sections.multicolumn.settings.title.label"
+    },
+    {
+      "type": "select",
+      "id": "heading_size",
+      "options": [
+        {
+          "value": "h2",
+          "label": "t:sections.all.heading_size.options__1.label"
+        },
+        {
+          "value": "h1",
+          "label": "t:sections.all.heading_size.options__2.label"
+        },
+        {
+          "value": "h0",
+          "label": "t:sections.all.heading_size.options__3.label"
+        }
+      ],
+      "default": "h1",
+      "label": "t:sections.all.heading_size.label"
+    },
+    {
+      "type": "header",
+      "content": "Tab Styling"
+    },
+    {
+      "type": "color",
+      "id": "active_tab_background",
+      "label": "Active Tab Background Color",
+      "default": "#000000"
+    },
+    {
+      "type": "color",
+      "id": "active_tab_text_color",
+      "label": "Active Tab Text Color",
+      "default": "#ffffff"
+    },
+    {
+      "type": "color",
+      "id": "active_tab_border_color",
+      "label": "Active Tab Border Color",
+      "default": "#000000"
+    },
+    {
+      "type": "color",
+      "id": "active_tab_underline_color",
+      "label": "Active Tab Underline Color",
+      "default": "#000000"
+    },
+    {
+      "type": "color",
+      "id": "tab_background_color",
+      "label": "Tab Background Color",
+      "default": "transparent"
+    },
+    {
+      "type": "color",
+      "id": "tab_border_color",
+      "label": "Tab Border Color",
+      "default": "transparent"
+    },
+    {
+      "type": "color",
+      "id": "tab_hover_background",
+      "label": "Tab Hover Background Color",
+      "default": "#f5f5f5"
+    },
+    {
+      "type": "range",
+      "id": "tab_border_radius",
+      "min": 0,
+      "max": 20,
+      "step": 1,
+      "unit": "px",
+      "label": "Tab Border Radius",
+      "default": 0
+    },
+    {
+      "type": "range",
+      "id": "tab_border_width",
+      "min": 0,
+      "max": 5,
+      "step": 1,
+      "unit": "px",
+      "label": "Tab Border Width",
+      "default": 0
+    },
+    {
+      "type": "select",
+      "id": "image_width",
+      "options": [
+        {
+          "value": "third",
+          "label": "t:sections.multicolumn.settings.image_width.options__1.label"
+        },
+        {
+          "value": "half",
+          "label": "t:sections.multicolumn.settings.image_width.options__2.label"
+        },
+        {
+          "value": "full",
+          "label": "t:sections.multicolumn.settings.image_width.options__3.label"
+        }
+      ],
+      "default": "full",
+      "label": "t:sections.multicolumn.settings.image_width.label"
+    },
+    {
+      "type": "select",
+      "id": "image_ratio",
+      "options": [
+        {
+          "value": "adapt",
+          "label": "t:sections.multicolumn.settings.image_ratio.options__1.label"
+        },
+        {
+          "value": "portrait",
+          "label": "t:sections.multicolumn.settings.image_ratio.options__2.label"
+        },
+        {
+          "value": "square",
+          "label": "t:sections.multicolumn.settings.image_ratio.options__3.label"
+        },
+        {
+          "value": "circle",
+          "label": "t:sections.multicolumn.settings.image_ratio.options__4.label"
+        }
+      ],
+      "default": "adapt",
+      "label": "t:sections.multicolumn.settings.image_ratio.label"
+    },
+    {
+      "type": "range",
+      "id": "columns_desktop",
+      "min": 1,
+      "max": 6,
+      "step": 1,
+      "default": 3,
+      "label": "t:sections.multicolumn.settings.columns_desktop.label"
+    },
+    {
+      "type": "select",
+      "id": "column_alignment",
+      "options": [
+        {
+          "value": "left",
+          "label": "t:sections.multicolumn.settings.column_alignment.options__1.label"
+        },
+        {
+          "value": "center",
+          "label": "t:sections.multicolumn.settings.column_alignment.options__2.label"
+        }
+      ],
+      "default": "left",
+      "label": "t:sections.multicolumn.settings.column_alignment.label"
+    },
+    {
+      "type": "select",
+      "id": "background_style",
+      "options": [
+        {
+          "value": "none",
+          "label": "t:sections.multicolumn.settings.background_style.options__1.label"
+        },
+        {
+          "value": "primary",
+          "label": "t:sections.multicolumn.settings.background_style.options__2.label"
+        }
+      ],
+      "default": "primary",
+      "label": "t:sections.multicolumn.settings.background_style.label"
+    },
+    {
+      "type": "text",
+      "id": "button_label",
+      "default": "Button label",
+      "label": "t:sections.multicolumn.settings.button_label.label"
+    },
+    {
+      "type": "url",
+      "id": "button_link",
+      "label": "t:sections.multicolumn.settings.button_link.label"
+    },
+    {
+      "type": "color_scheme",
+      "id": "color_scheme",
+      "label": "t:sections.all.colors.label",
+      "default": "background-1"
+    },
+    {
+      "type": "header",
+      "content": "t:sections.multicolumn.settings.header_mobile.content"
+    },
+    {
+      "type": "select",
+      "id": "columns_mobile",
+      "options": [
+        {
+          "value": "1",
+          "label": "t:sections.multicolumn.settings.columns_mobile.options__1.label"
+        },
+        {
+          "value": "2",
+          "label": "t:sections.multicolumn.settings.columns_mobile.options__2.label"
+        }
+      ],
+      "default": "1",
+      "label": "t:sections.multicolumn.settings.columns_mobile.label"
+    },
+    {
+      "type": "checkbox",
+      "id": "swipe_on_mobile",
+      "default": false,
+      "label": "t:sections.multicolumn.settings.swipe_on_mobile.label"
+    },
+    {
+      "type": "header",
+      "content": "t:sections.all.padding.section_padding_heading"
+    },
+    {
+      "type": "range",
+      "id": "padding_top",
+      "min": 0,
+      "max": 100,
+      "step": 4,
+      "unit": "px",
+      "label": "t:sections.all.padding.padding_top",
+      "default": 36
+    },
+    {
+      "type": "range",
+      "id": "padding_bottom",
+      "min": 0,
+      "max": 100,
+      "step": 4,
+      "unit": "px",
+      "label": "t:sections.all.padding.padding_bottom",
+      "default": 36
+    }
+  ],
+  "blocks": [
+    {
+      "type": "column",
+      "name": "t:sections.multicolumn.blocks.column.name",
+      "settings": [
+        {
+          "type": "text",
+          "id": "tab_name",
+          "label": "Tab Name",
+          "info": "Enter the tab name. Columns with the same tab name will be grouped together."
+        },
+        {
+          "type": "url",
+          "id": "tab_url",
+          "label": "Tab URL",
+          "info": "URL to navigate to when this tab is clicked (optional)"
+        },
+        {
+          "type": "image_picker",
+          "id": "image",
+          "label": "t:sections.multicolumn.blocks.column.settings.image.label"
+        },
+        {
+          "type": "inline_richtext",
+          "id": "title",
+          "default": "Column",
+          "label": "t:sections.multicolumn.blocks.column.settings.title.label"
+        },
+        {
+          "type": "richtext",
+          "id": "text",
+          "default": "<p>Pair text with an image to focus on your chosen product, collection, or blog post. Add details on availability, style, or even provide a review.</p>",
+          "label": "t:sections.multicolumn.blocks.column.settings.text.label"
+        },
+        {
+          "type": "text",
+          "id": "link_label",
+          "label": "t:sections.multicolumn.blocks.column.settings.link_label.label"
+        },
+        {
+          "type": "url",
+          "id": "link",
+          "label": "t:sections.multicolumn.blocks.column.settings.link.label"
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "Multicolumn Tabs",
+      "blocks": [
+        {
+          "type": "column",
+          "settings": {
+            "tab_name": "Tab 1"
+          }
+        },
+        {
+          "type": "column",
+          "settings": {
+            "tab_name": "Tab 1"
+          }
+        },
+        {
+          "type": "column",
+          "settings": {
+            "tab_name": "Tab 2"
+          }
+        },
+        {
+          "type": "column",
+          "settings": {
+            "tab_name": "Tab 2"
+          }
+        }
+      ]
+    }
+  ]
+}
+{% endschema %}


### PR DESCRIPTION
Creates a new Shopify section `multicolumn-tabs.liquid` that transforms the standard multicolumn layout into a tabbed interface.

This PR enables content grouping into distinct tabs, each with customizable active styling and the ability to link to different URLs.

---
<a href="https://cursor.com/background-agent?bcId=bc-92c196cc-2883-4e2e-97ab-dd782197b305">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-92c196cc-2883-4e2e-97ab-dd782197b305">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

